### PR TITLE
feat: adds flag to install version from a go.mod file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
     - [See all versions including release candidates (rc)](#see-all-versions-including-release-candidates-rc)
     - [Install latest version](#install-latest-version)
     - [Install specific version](#install-specific-version)
+    - [Install from mod file](#install-from-mod-file)
     - [Delete unused versions](#delete-unused-versions)
     - [Refresh version list](#refresh-version-list)
     - [Help](#help)
@@ -142,7 +143,7 @@ Use the arrow keys to navigate: ↓ ↑ → ←
 
 ### Install latest version
 
-In order to install the latest stable version, use the `--install-latest`.
+To install the latest stable version, use the `--install-latest`.
 
 ```sh
 $ gvs --install-latest
@@ -155,7 +156,7 @@ Installing version...
 
 ### Install specific version
 
-In order to install a specific version without using the dropdown, use the `--install-version=value`.
+To install a specific version without using the dropdown, use the `--install-version=value`.
 
 ```sh
 $ gvs --install-version=1.21.3
@@ -172,6 +173,18 @@ If the `Patch` version is not specified (`--install-version=1.21`), the latest `
 
 You can also pass Release Candidates, like `1.21rc2`.
 
+### Install from mod file
+
+You can also install a version that is specified in a go.mod file. You can use the flag `--from-mod`. This will look for any `go.mod` file under the same path `gvs` was executed on the terminal.
+
+```sh
+$ gvs --from-mod
+Downloading...
+Compare Checksums...
+Unzipping...
+Installing version...
+1.21.3 version is installed!
+```
 
 ### Delete unused versions
 

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,6 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	golang.org/x/mod v0.13.0
 	golang.org/x/sys v0.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
+golang.org/x/mod v0.13.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=


### PR DESCRIPTION
## Description

Introduces a new flag, that can be used to install a version that is specified in a `go.mod` file. The file location should be the same as where the cli is executed.

The flag is called `from-mod` and can be used like:

```sh
$ gvs --from-mod
```

## How to test that change

## How to test that change

1. Build the cli
2. move the build CLI to some path that is included on the $PATH
3. navigate to any go project that contains a go.mod file
4. Run `gvs --from-mod` under the same path

<!-- Modify issue url. -->

Fixes https://github.com/VassilisPallas/gvs/issues

## Checklist

Tests

- [ ] I've added integration tests
- [ ] I've added unit tests

Documentation

- [x] I've updated readme

Review process

- [x] The title is in present tense and includes the issue number
- [x] I've used [conventional commits](https://www.conventionalcommits.org/)
- [ ] I have added the issue link on the PR