### PR TITLE
feat: support multiple flags together

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,6 @@ Fixes https://github.com/VassilisPallas/gvs/issues
 
 Tests
 
-- [ ] I've added integration tests
 - [ ] I've added unit tests
 
 Documentation

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Installing version...
 
 ### Install specific version
 
-To install a specific version without using the dropdown, use the `--install-version=value`.
+To install a specific version without using the dropdown, use the `--install-version=value` flag.
 
 ```sh
 $ gvs --install-version=1.21.3
@@ -190,10 +190,24 @@ Installing version...
 
 Every time you install a new version, gvs keeps the previous installed versions, so you can easily change between them. If you want to delete all the unused versions and keep only the current one, use the `--delete-unused` flag.
 
-In the below example, the versions `1.20` and `1.19` are previously installed, and since they are not used (neither of them is the current version you use), they will be deleted.
+In the below example, the versions `1.20` and `1.19` are previously installed, and since they are not used (neither of them is the current version you use), they will be deleted after installing the new version 1.21.2.
 
 ```sh
 $ gvs --delete-unused
+Use the arrow keys to navigate: ↓ ↑ → ←
+? Select go version: 
+    1.21.3
+  ▸ 1.21.2
+    1.21.1
+    1.21.0
+    1.20.10
+
+✔ 1.21.2
+Downloading...
+Compare Checksums...
+Unzipping...
+Installing version...
+1.21.2 version is installed!
 Deleting go1.20.
 go1.20 is deleted.
 Deleting go1.19.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+
+	"github.com/VassilisPallas/gvs/logger"
+	"github.com/VassilisPallas/gvs/version"
+)
+
+type CLI struct {
+	versions  []*version.ExtendedVersion
+	versioner version.Versioner
+	log       logger.Logger
+}
+
+func (cli CLI) Install(selectedVersion *version.ExtendedVersion) error {
+	cli.log.Info("selected %s version\n", selectedVersion.Version)
+	return cli.versioner.Install(selectedVersion, runtime.GOOS, runtime.GOARCH)
+}
+
+func (cli CLI) InstallVersion(goVersion string) error {
+	semver := &version.Semver{}
+	err := version.ParseSemver(goVersion, semver)
+	if err != nil {
+		return err
+	}
+
+	selectedVersion := cli.versioner.FindVersionBasedOnSemverName(cli.versions, semver)
+	if selectedVersion != nil {
+		return fmt.Errorf("%s is not a valid version", semver.GetVersion())
+	}
+
+	return cli.Install(selectedVersion)
+}
+
+func (cli CLI) InstallLatestVersion() error {
+	selectedIndex := cli.versioner.GetLatestVersion(cli.versions)
+	if selectedIndex == -1 {
+		return errors.New("latest version not found")
+	}
+
+	selectedVersion := cli.versions[selectedIndex]
+
+	return cli.Install(selectedVersion)
+}
+
+func (cli CLI) DeleteUnusedVersions() error {
+	deleted_count, err := cli.versioner.DeleteUnusedVersions(cli.versions)
+	if err != nil {
+		return err
+	}
+
+	if deleted_count > 0 {
+		cli.log.PrintMessage("All the unused version are deleted!")
+	} else {
+		cli.log.PrintMessage("Nothing to delete")
+	}
+
+	return nil
+}
+
+func New(versions []*version.ExtendedVersion, versioner version.Versioner, log logger.Logger) CLI {
+	return CLI{versions: versions, versioner: versioner, log: log}
+}

--- a/files/files.go
+++ b/files/files.go
@@ -14,6 +14,7 @@ import (
 	"github.com/VassilisPallas/gvs/clock"
 	"github.com/VassilisPallas/gvs/logger"
 	"github.com/VassilisPallas/gvs/pkg/unzip"
+	"golang.org/x/mod/modfile"
 )
 
 // FileHelpers is the interface that wraps the basic methods for working with files.
@@ -79,6 +80,8 @@ type FileHelpers interface {
 	// GetLatestCreatedGoVersionDirectory must return the name of the latest modified directory and
 	// a non-null error if the operation is successful.
 	GetLatestCreatedGoVersionDirectory() (string, error)
+
+	ReadVersionFromMod() (string, error)
 }
 
 // Helper is the struct that implements the FileHelpers interface
@@ -369,6 +372,20 @@ func (h Helper) GetLatestCreatedGoVersionDirectory() (string, error) {
 	}
 
 	return dirName, nil
+}
+
+func (h Helper) ReadVersionFromMod() (string, error) {
+	buf, err := h.fileSystem.ReadFile("./go.mod")
+	if err != nil {
+		return "", err
+	}
+
+	f, err := modfile.Parse("go.mod", buf, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return f.Go.Version, nil
 }
 
 // New returns a *Helper instance that implements the FileHelpers interface.

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -9,8 +9,11 @@ import (
 
 // Flag contains the information for the flag.
 type Flag struct {
-	// The name of the flag
+	// The name of the flag.
 	name string
+
+	// a short name for the flag.
+	shortName string
 
 	// A boolean that represents if the flag expects a value to be passed.
 	//
@@ -25,6 +28,15 @@ type Flag struct {
 // If the flag expects a value, the result will be like: --some-flag=value
 func (f Flag) getHelpName() string {
 	flagName := fmt.Sprintf("--%s", f.name)
+
+	if f.acceptsVale {
+		flagName += "=value"
+	}
+
+	if f.shortName != "" {
+		flagName += fmt.Sprintf(", -%s", f.shortName)
+	}
+
 	if f.acceptsVale {
 		flagName += "=value"
 	}
@@ -39,20 +51,28 @@ type FlagSet struct {
 	flags []Flag
 }
 
-// FlagBool defines a bool flag with specified name, default value, and usage string.
+// FlagBool defines a bool flag with specified name, short name (single character), default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 // FlagBool also appends the flag to the FlagSet array.
-func (s *FlagSet) FlagBool(p *bool, name string, value bool, usage string) {
-	s.flags = append(s.flags, Flag{name: name, acceptsVale: false})
+func (s *FlagSet) FlagBool(p *bool, name string, shortName rune, value bool, usage string) {
+	s.flags = append(s.flags, Flag{name: name, shortName: string(shortName), acceptsVale: false})
 	flag.BoolVar(p, name, value, usage)
+
+	if string(shortName) != "" {
+		flag.BoolVar(p, string(shortName), value, usage)
+	}
 }
 
-// StringVar defines a string flag with specified name, default value, and usage string.
+// StringVar defines a string flag with specified name, short name (single character), default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 // FlagBool also appends the flag to the FlagSet array.
-func (s *FlagSet) FlagStr(p *string, name string, value string, usage string) {
-	s.flags = append(s.flags, Flag{name: name, acceptsVale: true})
+func (s *FlagSet) FlagStr(p *string, name string, shortName rune, value string, usage string) {
+	s.flags = append(s.flags, Flag{name: name, shortName: string(shortName), acceptsVale: true})
 	flag.StringVar(p, name, value, usage)
+
+	if string(shortName) != "" {
+		flag.StringVar(p, string(shortName), value, usage)
+	}
 }
 
 // printSynopsis returns back all the available flags without any description.

--- a/internal/testutils/fake_file_helpers.go
+++ b/internal/testutils/fake_file_helpers.go
@@ -146,3 +146,7 @@ func (fh FakeFilesHelper) CreateInitFiles() (*os.File, error) {
 func (fh FakeFilesHelper) GetLatestCreatedGoVersionDirectory() (string, error) {
 	return "", nil
 }
+
+func (fh FakeFilesHelper) ReadVersionFromMod() (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
## Description

Supports multiple flags together. Also added single (short) name for the flags.
- `--show-all` -> `-a`
- `--install-latest` -> `l`
- `--delete-unused` -> `-d`
- `--refresh-versions` -> `-r`
- `--install-version=value` -> `-v=value`
- `--from-mod` -> `-m`

**Breaking change**:
The flag `--delete-unused` is now executed as the last operation after installing a new version. That means, that running `gvs --delete-unused` will not delete the unused versions, but rather it will show the prompt first to choose a new version, and then after installing the new one, the unused ones will get deleted.

However, the flag now can be used alongside other flags, e.g. `gvs --install-latest --delete-unused`, `gvs --install-version 1.23 --delete-unused` etc.

## How to test that change

1. Build gvs
2. Use the `--delete-unused` flag in different combinations with the rest of the flags.
3. After installing the expected version, the unused ones should get deleted.

## Checklist

Tests

- [x] I've added unit tests

Documentation

- [x] I've updated readme

Review process

- [x] The title is in present tense and includes the issue number
- [x] I've used [conventional commits](https://www.conventionalcommits.org/)
- [ ] I have added the issue link on the PR