### PR TITLE
fix: Install semver version

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -28,7 +28,7 @@ func (cli CLI) InstallVersion(goVersion string) error {
 	}
 
 	selectedVersion := cli.versioner.FindVersionBasedOnSemverName(cli.versions, semver)
-	if selectedVersion != nil {
+	if selectedVersion == nil {
 		return fmt.Errorf("%s is not a valid version", semver.GetVersion())
 	}
 


### PR DESCRIPTION
## Description

Fixes the bug with the semver versions. There was an incorrect if statements that was preventing both version passed from the CLI and from go.mod files not be installed.

## Checklist

Tests

- [x] I've added unit tests

Documentation

- [ ] I've updated readme

Review process

- [x] The title is in present tense and includes the issue number
- [x] I've used [conventional commits](https://www.conventionalcommits.org/)
- [ ] I have added the issue link on the PR